### PR TITLE
fix: Update default branch from main to master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
       - completed
   push:
     branches:
-      - main
+      - master
       - develop
   workflow_dispatch: # Add this for manual triggers
     inputs:
@@ -82,7 +82,7 @@ jobs:
 
   cd-production:
     name: Deploy to Production
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' || github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - main
+      - master
       - develop
   pull_request:
     branches:
-      - main
+      - master
       - develop
 
 jobs:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @diesazul96


### PR DESCRIPTION
## ✨ Requirement

Fix naming of default branch from `main` to `master`

## ☑️ Change Type

- [x] ✨ New Feature

## 🛠 What's implemented on this PR

CI/CD configuration update to `master` branch name. And also add CODEOWNERS file to prevent PRs without owner approval
